### PR TITLE
Added bundling&minification with rollup&uglifyjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ node_modules
 ## File-based project format:
 *.ipr
 *.iws
+
+## Project outputs:
+bundle.js
+dist

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "shisell",
   "version": "0.2.0",
   "description": "A service agnostic JS library for building immutable scoped analytic event dispatchers with extra data, identities and lazy filters.",
-  "main": "index.js",
+  "main": "dist/shisell.umd.js",
+  "browser": "dist/shisell.umd.js",
+  "module": "dist/shisell.es.js",
+  "jsnext:main": "dist/shisell.es.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test"
+    "test": "mocha test",
+    "build": "rimraf dist && rollup -c"
   },
   "repository": {
     "type": "git",
@@ -17,11 +21,15 @@
   ],
   "author": "Soluto",
   "license": "MIT",
-  "dependencies": {},
   "devDependencies": {
-    "chai": "^3.4.0",
-    "mocha": "2.3.3",
-    "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "chai": "^4.0.2",
+    "mocha": "^3.4.2",
+    "rimraf": "^2.6.1",
+    "rollup": "^0.43.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-uglify": "^2.0.1",
+    "sinon": "^2.3.6",
+    "sinon-chai": "^2.11.0",
+    "uglify-es": "^3.0.23"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+import commonjs from 'rollup-plugin-commonjs';
+import uglify from 'rollup-plugin-uglify';
+import {minify} from 'uglify-es';
+
+export default {
+    entry: 'index.js',
+    plugins: [
+        commonjs(),
+        uglify({}, minify)
+    ],
+    targets: [
+        { dest: 'dist/shisell.umd.js', format: 'umd', moduleName: 'shisell' },
+        { dest: 'dist/shisell.es.js', format: 'es' }
+    ]
+}


### PR DESCRIPTION
Related to #24 
This creates two bundles, and references to them in the package file:
1. UMD bundle, directed to by the `main` and `browser` fields, for node, webpack 1 and in-browser usage
2. ES bundle, directed to by the `module` and `jsnext:main` fields, for webpack2/rollup usage

If typescript/es2015+ features will be added we'd need to add a babel/ts/whatever plugin into the rollup build
If/when this is written in typescript/es modules, `main` should point to the CJS bundle/post-transpilation files, and `module`/`jsnext:main` to the ES modules. I think.
I only sort of understand this bundling stuff, so feedback would actually be welcome, learned most of it here:
[Webpack resolve documentation](https://webpack.js.org/configuration/resolve/#resolve-mainfields)
[Rollup module documentation](https://github.com/rollup/rollup/wiki/pkg.module)